### PR TITLE
fix: quiz builder, creating new quiz with questions and their answers is now possible

### DIFF
--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -9,7 +9,7 @@ class QuizzesController < ApplicationController
   def create
     @quiz = Quiz.new(quiz_create_params)
     @quiz.study_module.course = @course
-
+    # raise
     if @quiz.save
       redirect_to edit_course_path(@course, study_module_id: @quiz.study_module.id)
     else
@@ -63,8 +63,8 @@ class QuizzesController < ApplicationController
       .permit(
         :text,
         study_module_attributes: StudyModule.attribute_names.map(&:to_sym),
-        questions_attributes: Question.attribute_names.map(&:to_sym),
-        answers_attributes: Answer.attribute_names.map(&:to_sym)
+        questions_attributes: Question.attribute_names.map(&:to_sym).push(:_destroy)
+        .push(answers_attributes: Answer.attribute_names.map(&:to_sym).push(:_destroy))
       )
   end
 

--- a/app/javascript/controllers/nested_form_controller.js
+++ b/app/javascript/controllers/nested_form_controller.js
@@ -9,6 +9,12 @@ export default class extends Controller {
     this.add_itemTarget.insertAdjacentHTML('beforebegin', content)
   }
 
+  add_association_child(event) {
+    event.preventDefault()  
+    var content = this.templateTarget.innerHTML.replace(/TEMPLATE_CHILD/g, new Date().valueOf())
+    this.add_itemTarget.insertAdjacentHTML('beforebegin', content)
+  }
+
   remove_association(event) {
     event.preventDefault()
     let item = event.target.closest(".nested-fields")

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -27,12 +27,12 @@ require("@rails/actiontext")
 import "bootstrap";
 import "cocoon-js";
 // BEGIN - StimulusJS for nested form
-import { Application } from "stimulus"
-import { definitionsFromContext } from "stimulus/webpack-helpers"
+import { Application } from "stimulus";
+import { definitionsFromContext } from "stimulus/webpack-helpers";
 
-const application = Application.start()
-const context = require.context("../controllers", true, /\.js$/)
-application.load(definitionsFromContext(context))
+const application = Application.start();
+const context = require.context("../controllers", true, /\.js$/);
+application.load(definitionsFromContext(context));
 // END - StimulusJS for nested form
 
 // Internal imports, e.g:
@@ -43,7 +43,7 @@ document.addEventListener('turbolinks:load', () => {
   // initSelect2();
 });
 
-const Trix = require("trix")
+const Trix = require("trix");
 
 window.addEventListener("trix-initialize", (event) => {
 

--- a/app/views/quizzes/_form.html.erb
+++ b/app/views/quizzes/_form.html.erb
@@ -10,13 +10,13 @@
   <!-- QUESTIONS LISTS -->
   <div data-controller="nested-form">
     <template data-target='nested-form.template'>
-      <%= form.simple_fields_for :questions, Question.new, child_index: 'TEMPLATE_RECORD' do |question| %>
-        <%= render "#{contentable.class.table_name}/question_fields", form: question, contentable: contentable %>
+      <%= form.simple_fields_for :questions, Question.new, child_index: 'TEMPLATE_RECORD' do |question_form| %>
+        <%= render "#{contentable.class.table_name}/question_fields", form: question_form, contentable: contentable %>
       <% end %>
     </template>
 
-    <%= form.simple_fields_for :questions do |question| %>
-      <%= render "#{contentable.class.table_name}/question_fields", form: question, contentable: contentable %>
+    <%= form.simple_fields_for :questions do |question_form| %>
+      <%= render "#{contentable.class.table_name}/question_fields", form: question_form, contentable: contentable %>
     <% end %>
 
     <div data-target="nested-form.add_item">

--- a/app/views/quizzes/_question_fields.html.erb
+++ b/app/views/quizzes/_question_fields.html.erb
@@ -12,17 +12,17 @@
   <!-- ANSWER LISTS -->
   <div class="answers-group" data-controller="nested-form">
     <template data-target='nested-form.template'>
-      <%= form.simple_fields_for :answers, Answer.new, child_index: 'TEMPLATE_RECORD' do |answer| %>
-        <%= render "#{contentable.class.table_name}/answer_fields", subform: answer %>
+      <%= form.simple_fields_for :answers, Answer.new, child_index: 'TEMPLATE_CHILD' do |answer_form| %>
+        <%= render "#{contentable.class.table_name}/answer_fields", subform: answer_form %>
       <% end %>
     </template>
 
-    <%= form.simple_fields_for :answers do |answer| %>
-      <%= render "#{contentable.class.table_name}/answer_fields", subform: answer %>
+    <%= form.simple_fields_for :answers do |answer_form| %>
+      <%= render "#{contentable.class.table_name}/answer_fields", subform: answer_form %>
     <% end %>
 
     <div data-target="nested-form.add_item" class="text-right">
-      <%= link_to "+ Choice", "#", data: { action: "nested-form#add_association" }, class: "small" %>
+      <%= link_to "+ Choice", "#", data: { action: "nested-form#add_association_child" }, class: "small" %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
fix: quiz builder, when creating new quiz, answers can now be save along with associated question

before this fix, when creating new quiz, each question only be saved with the last answer