### PR TITLE
fix: navbar enforced User.role into display items

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -7,6 +7,7 @@
 <div class = "card mx-3 my-5 p-3">
   <p>Category: <%= @course.category %></p>
   <p><%= @course.description %></p>
+
   <%= if (current_user.student?)
     link_to_unless (current_user.enrollments.map(&:course).include?(@course)), "Enroll", course_enrollments_path(@course), method: :post, class: "btn btn-primary" do
       link_to "Study", study_course_path(@course), class: "btn btn-primary "

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -16,10 +16,10 @@
             </div>
             <div class= "row mt-5">
             <%= link_to_if(@current_user.nil?, "Start Teaching", new_user_session_path, class: "border border-dark p-3 rounded text-dark col-12 col-md-5 mr-2") do 
-              link_to "Start Teaching #{icon("fas", "arrow-right")}".html_safe, user_courses_path(current_user), class: "border border-dark p-3 rounded text-dark col-12 col-md-5 mr-2"
+              link_to "Start Teaching #{icon("fas", "arrow-right")}".html_safe, user_courses_path(current_user), class: "border border-dark p-3 rounded text-dark col-12 col-md-5 mr-2" if current_user.teacher?
             end %>
             <%= link_to_if(@current_user.nil?, "Start Studying", new_user_session_path, class: "border border-dark p-3 rounded text-dark col-12 col-md-5 mr-2") do
-              link_to "Start Studying #{icon("fas", "arrow-right")}".html_safe, user_enrollments_path(current_user), class: "border border-dark p-3 rounded text-dark col-12 col-md-5"
+              link_to "Start Studying #{icon("fas", "arrow-right")}".html_safe, user_enrollments_path(current_user), class: "border border-dark p-3 rounded text-dark col-12 col-md-5" if current_user.student?
             end %>
             <%#= link_to "Start Teaching", user_courses_path(current_user), class: "border border-dark p-3 rounded text-dark col-12 col-md-5 mr-2" %>
             <%#= link_to "Start Studying", user_enrollments_path(current_user), class: "border border-dark p-3 rounded text-dark col-12 col-md-5" %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -17,10 +17,10 @@
           <%= link_to "Home", root_path, class: "nav-link" %>
         </li>
         <li class="nav-item">
-          <%= link_to "Teach", user_courses_path(current_user), class: "nav-link" %>
+          <%= link_to "Teach", user_courses_path(current_user), class: "nav-link" if current_user.teacher? %>
         </li>
         <li class="nav-item">
-          <%= link_to "Study", user_enrollments_path(current_user), class: "nav-link" %>
+          <%= link_to "Study", user_enrollments_path(current_user), class: "nav-link" if current_user.student? %>
         </li>
         <%# Messages %>
         <%= render "shared/navbar_chatrooms", current_user: current_user, role: "teacher" %>

--- a/app/views/shared/_navbar_chatrooms.html.erb
+++ b/app/views/shared/_navbar_chatrooms.html.erb
@@ -2,26 +2,25 @@
   <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     Messages
   </a>
-  <div class="dropdown-menu text-center" aria-labelledby="navbarDropdown">
+  <div class="dropdown-menu" aria-labelledby="navbarDropdown">
     <%# List user's courses & link to the chatroom %>    
-    <% if !current_user.courses.empty? && role == "teacher" %>
-      <strong style="text-decoration: underline"> Courses </strong>
+    <% if !current_user.courses.empty? && current_user.teacher? %>
       <% current_user.courses.each do |course| %>
         <%=link_to_unless_current course.name, chat_course_path(course), class: "dropdown-item" %>
       <% end %>
-      <hr>
     <% end %>
     
     <%# List user's enrollments & link to the chatroom %>
-    <% if !current_user.enrollments.empty? && role == "student" %>
-      <strong style="text-decoration: underline"> Enrollments </strong>
+    <% if !current_user.enrollments.empty? && current_user.student? %>
       <% current_user.enrollments.each do |enrollment| %>
         <%= link_to enrollment.course.name, chat_course_path(enrollment.course), class: "dropdown-item" %>
       <% end %>
     <% end %>
     <%# If user has no courses %>
-    <% if current_user.enrollments.empty? && current_user.courses.empty?%>
-      No courses!
+    <% if current_user.student? && current_user.enrollments.empty? %>
+      No enrollment!
+    <% elsif current_user.teacher? && current_user.courses.empty?%>
+      No course!
     <% end %>
   </div>
 </li>


### PR DESCRIPTION
Enhanced Navbar with User.role attribute:
For Teacher:
no longer show "Study" navitem

For Student:
No longer show "Teach" navitem
